### PR TITLE
Changed condition in StorageController.LoadAsync method to check for …

### DIFF
--- a/Parse/Internal/Storage/Controller/StorageController.cs
+++ b/Parse/Internal/Storage/Controller/StorageController.cs
@@ -156,7 +156,14 @@ namespace Parse.Common.Internal
         /// Loads a settings dictionary from the file wrapped by <see cref="File"/>.
         /// </summary>
         /// <returns>A storage dictionary containing the deserialized content of the storage file targeted by the <see cref="StorageController"/> instance</returns>
-        public Task<IStorageDictionary<string, object>> LoadAsync() => Queue.Enqueue(toAwait => toAwait.ContinueWith(_ => Task.FromResult((IStorageDictionary<string, object>) Storage) ?? (Storage = new StorageDictionary(File)).LoadAsync().OnSuccess(__ => Storage as IStorageDictionary<string, object>)).Unwrap(), CancellationToken.None);
+        public Task<IStorageDictionary<string, object>> LoadAsync()
+        {
+            // check if storage dictionary is already created from the controllers file (create if not)
+            if (Storage == null)
+                Storage = new StorageDictionary(File);
+            // load storage dictionary content async and return the resulting dictionary type
+            return Queue.Enqueue(toAwait => toAwait.ContinueWith(_ => Storage.LoadAsync().OnSuccess(__ => Storage as IStorageDictionary<string, object>)).Unwrap(), CancellationToken.None);
+        }
 
         /// <summary>
         /// 

--- a/Parse/Internal/Utilities/StorageManager.cs
+++ b/Parse/Internal/Utilities/StorageManager.cs
@@ -31,7 +31,10 @@ namespace Parse.Internal.Utilities
         public static async Task WriteToAsync(this FileInfo file, string content)
         {
             using (FileStream stream = new FileStream(Path.GetFullPath(file.FullName), FileMode.Create, FileAccess.Write, FileShare.Read, 4096, FileOptions.SequentialScan | FileOptions.Asynchronous))
-                await stream.WriteAsync(Encoding.Unicode.GetBytes(content), 0, content.Length * 2 /* UTF-16, so two bytes per character of length. */);
+            {
+                byte[] data = Encoding.Unicode.GetBytes(content);
+                await stream.WriteAsync(data, 0, data.Length);
+            }
         }
 
         /// <summary>
@@ -41,7 +44,7 @@ namespace Parse.Internal.Utilities
         /// <returns>A task that should contain the little-endian 16-bit character string (UTF-16) extracted from the <paramref name="file"/> if the read completes successfully</returns>
         public static async Task<string> ReadAllTextAsync(this FileInfo file)
         {
-            using (StreamReader reader = file.OpenText())
+            using (StreamReader reader = new StreamReader(file.OpenRead(), Encoding.Unicode))
                 return await reader.ReadToEndAsync();
         }
 
@@ -72,14 +75,15 @@ namespace Parse.Internal.Utilities
         {
             path = Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), path));
 
-            Directory.CreateDirectory(path.Substring(0, path.LastIndexOf(Path.VolumeSeparatorChar)));
+            Directory.CreateDirectory(path.Substring(0, path.LastIndexOf(Path.DirectorySeparatorChar)));
             return new FileInfo(path);
         }
 
         public static async Task TransferAsync(string originFilePath, string targetFilePath)
         {
             if (!String.IsNullOrWhiteSpace(originFilePath) && !String.IsNullOrWhiteSpace(targetFilePath) && new FileInfo(originFilePath) is FileInfo originFile && originFile.Exists && new FileInfo(targetFilePath) is FileInfo targetFile)
-                using (StreamWriter writer = targetFile.CreateText()) using (StreamReader reader = originFile.OpenText())
+                using (StreamWriter writer = new StreamWriter(targetFile.OpenWrite(), Encoding.Unicode))
+                using (StreamReader reader = new StreamReader(originFile.OpenRead(), Encoding.Unicode))
                     await writer.WriteAsync(await reader.ReadToEndAsync());
         }
     }

--- a/Parse/Public/ParseClient.cs
+++ b/Parse/Public/ParseClient.cs
@@ -251,10 +251,10 @@ namespace Parse
 
                 switch (configuration.StorageConfiguration)
                 {
-                    case IStorageController controller when !(controller is null):
+                    case null:
+                        configuration.StorageConfiguration = Configuration.MetadataBasedStorageConfiguration.NoCompanyInferred;
                         break;
                     default:
-                        configuration.StorageConfiguration = Configuration.MetadataBasedStorageConfiguration.NoCompanyInferred;
                         break;
                 }
 
@@ -263,6 +263,7 @@ namespace Parse
                 ParseObject.RegisterSubclass<ParseUser>();
                 ParseObject.RegisterSubclass<ParseRole>();
                 ParseObject.RegisterSubclass<ParseSession>();
+                ParseObject.RegisterSubclass<ParseInstallation>();
 
                 ParseModuleController.Instance.ParseDidInitialize();
             }

--- a/Parse/Public/ParseInstallation.cs
+++ b/Parse/Public/ParseInstallation.cs
@@ -284,7 +284,7 @@ namespace Parse
                 return base.SaveAsync(toAwait, cancellationToken);
             }).Unwrap().OnSuccess(_ =>
             {
-                if (CurrentInstallationController.IsCurrent(this))
+                if (!CurrentInstallationController.IsCurrent(this))
                 {
                     return Task.FromResult(0);
                 }


### PR DESCRIPTION
…null reference prior to create new StorageDictionary instance and trying loading its data from disk

Changed file write and read methods in StorageManager class to use unified Unicode encoding
Changed use of VolumeSeparatorChar to DirectorySeparatorChar as it is used in context of creating a relative folder insider the local app data special folder
Changed ParseClient.Initialize behaviour to use MetadataBasedStorageConfiguration.NoCompanyInferred as default configuration of no other was set (did override any existing with the old switch statement)
Added subclass registration of ParseInstallation class which caused an error with the other changes made when reading and parsing local cached information to an ParseInstallation instance at runtime.